### PR TITLE
Don't catch until bin.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/node-riffraff-artifact",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "description": "Creates and upload artifacts for deployment using riffraff.",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/node-riffraff-artifact",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Creates and upload artifacts for deployment using riffraff.",
   "main": "index.js",
   "license": "MIT",

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -71,9 +71,7 @@ const uploadCompressed = (manifest: Manifest, action: Action) => {
     throw new Error("Attempted to compress something when compress was false.");
   }
   const stream = new PassThrough();
-  compressToStream(action.path, action.compress, stream).catch(_ =>
-    console.log(_)
-  );
+  compressToStream(action.path, action.compress, stream);
 
   return Promise.all([
     uploadStream(


### PR DESCRIPTION
There was a stray catch allowing builds to fail green.
Have removed. @twrichards 