### PR TITLE
chore(deps): Pin aws-sdk to v2.893.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mojotech/json-type-validation": "^3.1.0",
     "@types/temp": "^0.8.34",
     "archiver": "^3.1.1",
-    "aws-sdk": "^2.610.0",
+    "aws-sdk": "2.893.0",
     "ora": "^4.0.3",
     "temp": "^0.9.1",
     "yaml": "^1.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,7 +251,22 @@ async@^2.6.3:
   dependencies:
     lodash "^4.17.14"
 
-aws-sdk@>=2.169.0, aws-sdk@^2.610.0:
+aws-sdk@2.893.0:
+  version "2.893.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.893.0.tgz#953116eeef20ed7ced1ee081ec249af6644ccf44"
+  integrity sha512-yebi0KfJSyYcaYF+sDJ6Wq7OLq/8VZZiP7mN3fYfE3XZQV9MUYHMITqyeVxKG8BMvzkYfr6gpx1XZOJAYzfvJQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@>=2.169.0:
   version "2.610.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.610.0.tgz#a8633204bed83df763095824f8110ced4a717d2a"
   integrity sha512-kqcoCTKjbxrUo2KeLQR2Jw6l4PvkbHXSDk8KqF2hXcpHibiOcMXZZPVe9X+s90RC/B2+qU95M7FImp9ByMcw7A==
@@ -283,11 +298,6 @@ bl@^3.0.0:
   dependencies:
     readable-stream "^3.0.1"
 
-bluebird@^3.5.1:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -310,6 +320,15 @@ buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -704,16 +723,6 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.6.4.tgz#f46f0c75b7841f8d200b3348cd4d691d5a099d15"
-  integrity sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=
-  dependencies:
-    jsonfile "~1.0.1"
-    mkdirp "0.3.x"
-    ncp "~0.4.2"
-    rimraf "~2.2.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -907,11 +916,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-jsonfile@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-1.0.1.tgz#ea5efe40b83690b98667614a7392fc60e842c0dd"
-  integrity sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0=
-
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -998,26 +1002,12 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-mkdirp@0.3.x:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
-  integrity sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=
-
 mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mock-aws-s3@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mock-aws-s3/-/mock-aws-s3-3.0.0.tgz#33b4a389719571e82e71bb169c365123ec79936c"
-  integrity sha512-mvDwXrMvxghpXwntztuVGpdEt671DvRYWjJ9fojsKuFB8w782CzNNmp45mXmY8noimpopKWsrKXUZzOq3MZVEA==
-  dependencies:
-    bluebird "^3.5.1"
-    fs-extra "0.6.4"
-    underscore "1.8.3"
 
 ms@^2.1.1:
   version "2.1.2"
@@ -1033,11 +1023,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-ncp@~0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
-  integrity sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -1243,11 +1228,6 @@ rimraf@2.6.3, rimraf@~2.6.2:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
-
-rimraf@~2.2.0:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-  integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1496,11 +1476,6 @@ typescript@^3.7.5:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
-
-underscore@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Running `@guardian/node-riffraff-artifact` via `npx` (`npx @guardian/node-riffraff-artifact`) is common in CI.

Fixes an error where, when using `@guardian/node-riffraff-artifact` via `npx`, the following error is seen:

```console
internal/modules/cjs/loader.js:883
08:06:27
      throw err;
08:06:27
      ^
08:06:27
    08:06:27
    Error: Cannot find module '/root/.npm/_npx/248/lib/node_modules/@guardian/node-riffraff-artifact/node_modules/aws-sdk/scripts/check-node-version.js'
08:06:27
        at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
08:06:27
        at Function.Module._load (internal/modules/cjs/loader.js:725:27)
08:06:27
        at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
08:06:27
        at internal/main/run_main_module.js:17:47 {
08:06:27
      code: 'MODULE_NOT_FOUND',
08:06:27
      requireStack: []
08:06:27
    }
08:06:27
    npm ERR! code ELIFECYCLE
08:06:27
    npm ERR! errno 1
08:06:27
    npm ERR! aws-sdk@2.897.0 postinstall: `node scripts/check-node-version.js`
08:06:27
    npm ERR! Exit status 1
08:06:27
    npm ERR!
08:06:27
    npm ERR! Failed at the aws-sdk@2.897.0 postinstall script.
08:06:27
    npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
08:06:27
    08:06:27
    npm ERR! A complete log of this run can be found in:
08:06:27
    npm ERR!     /root/.npm/_logs/2021-05-03T07_06_27_225Z-debug.log
08:06:27
    Install for [ '@guardian/node-riffraff-artifact@latest' ] failed with code 1
08:06:29
    Process exited with code 1
```

It looks like since v2.894.0 aws-sdk attempts to run `node scripts/check-node-version.js` on install which fails.

I don't fully understand the root cause for this. The post install script is clearly being run and if I browse `node_modules` I can see the `check-node-version.js` file. I can, however, reliably reproduce the behaviour locally in an isolated environment via Docker:

```console
➜ docker run -it --rm --name test node:8.16.2 /bin/bash -c "npx @guardian/node-riffraff-artifact"
module.js:550
    throw err;
    ^

Error: Cannot find module '/root/.npm/_npx/1/lib/node_modules/@guardian/node-riffraff-artifact/node_modules/aws-sdk/scripts/check-node-version.js'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! aws-sdk@2.900.0 postinstall: `node scripts/check-node-version.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the aws-sdk@2.900.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-05-05T12_03_27_498Z-debug.log
Install for @guardian/node-riffraff-artifact@latest failed with code 1
```

Pinning this dependency to v2.893.0 exactly to overcome this issue.

See:
  - https://github.com/aws/aws-sdk-js/pull/3727

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

???

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We can successfully run `npx @guardian/node-riffraff-artifact` in CI.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We do not stay up to date with aws-cdk.