### PR TITLE
Support github actions

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,7 +6,7 @@ export interface Action {
   compress: false | "zip" | "tar";
 }
 
-type environment = "circle-ci" | "travis-ci" | "jenkins" | "teamcity" | "dev";
+type environment = "circle-ci" | "travis-ci" | "jenkins" | "teamcity" | "github-actions" | "dev";
 
 const determineEnvironment = (): environment => {
   if (process.env.CIRCLECI && process.env.CI) {
@@ -17,6 +17,8 @@ const determineEnvironment = (): environment => {
     return "jenkins";
   } else if (process.env.TEAMCITY_VERSION) {
     return "teamcity";
+  } else if (process.env.GITHUB_WORKFLOW) {
+    return "github-actions"
   } else {
     return "dev";
   }
@@ -40,6 +42,11 @@ export const getBranchName = (env: environment): string | undefined => {
         .split("/")
         .slice(-1)[0];
 
+    case "github-actions":
+      return (process.env.GITHUB_REF || "")
+        .split("/")
+        .slice(-1)[0];
+
     default:
       return undefined;
   }
@@ -59,6 +66,9 @@ export const getVcsRevision = (env: environment): string | undefined => {
     case "teamcity":
       return process.env.BUILD_VCS_NUMBER;
 
+    case "github-actions":
+      return process.env.GITHUB_SHA;
+
     default:
       return undefined;
   }
@@ -77,6 +87,10 @@ export const getBuildId = (env: environment): string | undefined => {
 
     case "teamcity":
       return process.env.BUILD_NUMBER;
+
+    case "github-actions":
+      return process.env.GITHUB_RUN_NUMBER;
+
     default:
       return undefined;
   }


### PR DESCRIPTION
This updates the environment detection of node-riffraff-artifact to support github actions. Following this change, node-riffraff-artifact will be able to detect if it is running on GHA and, if so, work out the useful stuff like branch name, build number etc. 

I used https://docs.github.com/en/actions/reference/environment-variables as a reference for these variables