### PR TITLE
chore: Update docs for running within GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ jobs:
       - run: npm run node-riffraff-artifact
 ```
 
+#### Migrating Riff-Raff project to GitHub Actions from TeamCity
+Riff-Raff will only trigger continuous deployment for builds of the default branch if the latest build number is greater than the previously deployed build number.
+
+If you've been running in TeamCity for a while you'll likely have a pretty large build number.
+When moving to GitHub Actions, the build number restarts from 1.
+Therefore, you'll likely witness your project's continuous deployment no longer working.
+
+To solve this, it is easiest to change the value of `projectName` within `artifact.json`, creating a new project in Riff-Raff. Once this change has been merged, you should also:
+
+1. Add a [restriction](https://riffraff.gutools.co.uk/deployment/restrictions/new) which prevents anyone from accidentally deploying the old Riff-Raff project.
+2. Update your [Continuous Deployment configuration](https://riffraff.gutools.co.uk/deployment/continuous) to use the new project name.
+3. Update your [Scheduled Deployment configuration](https://riffraff.gutools.co.uk/deployment/schedule) to use the new project name.
+4. Pause the TeamCity build configuration - this can be deleted entirely once you are confident that the GitHub Actions pipeline is working.
+   Be sure to pause the TeamCity project too.
+   Whilst this requires some co-ordination with your team, it is a one off process.
+
 ### Migrating from node-riffraff-artefact
 
 If your project uses [node-riffraff-artefact](https://github.com/guardian/node-riffraff-artefact) (with an e), then you can run


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Update the docs to detail how to use https://github.com/guardian/actions-assume-aws-role with this plugin, including a sample workflow file.