### PR TITLE
fix: Sanitise the default branch name in GHA

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -52,11 +52,13 @@ export const getBranchName = (env: environment): string | undefined => {
         .split("/")
         .slice(-1)[0];
 
-    case "github-actions":
+    case "github-actions": {
       // `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
       // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
       // See https://docs.github.com/en/actions/learn-github-actions/environment-variables
-      return process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF;
+      const branchName = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF;
+      return branchName ? branchName.replace("refs/heads/", "") : undefined;
+    }
 
     default:
       return undefined;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Upon merging into the default branch, the value of `GITHUB_REF` is `"refs/heads/main"`. Sanitise this for consistency.

https://github.com/guardian/sbt-riffraff-artifact/pull/62 is the SBT equivalent.