### PR TITLE
fix: Improve branch lookup from GitHub Actions

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -14,6 +14,13 @@ type environment =
   | "github-actions"
   | "dev";
 
+const envOrUndefined = (variableName: string): string | undefined => {
+  const maybeEnvVar = process.env[variableName];
+  return maybeEnvVar && maybeEnvVar.trim() !== ""
+    ? maybeEnvVar.trim()
+    : undefined;
+};
+
 const determineEnvironment = (): environment => {
   if (process.env.CIRCLECI && process.env.CI) {
     return "circle-ci";
@@ -55,8 +62,10 @@ export const getBranchName = (env: environment): string | undefined => {
     case "github-actions": {
       // `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
       // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
+      // Either can be the empty string ¯\_(ツ)_/¯
       // See https://docs.github.com/en/actions/learn-github-actions/environment-variables
-      const branchName = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF;
+      const branchName: string | undefined =
+        envOrUndefined("GITHUB_HEAD_REF") ?? envOrUndefined("GITHUB_REF");
       return branchName ? branchName.replace("refs/heads/", "") : undefined;
     }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The branch name within a GitHub Actions environment can be in one of two places:
  - `GITHUB_HEAD_REF` during PR builds
  - `GITHUB_REF` during a build

We read `GITHUB_HEAD_REF` and fallback to `GITHUB_REF`.

Either can be the empty string which is not very useful, especially as Riff-Raff uses branch names for continuous and scheduled deployment.

This change guards against this possibility by checking an env var isn't empty. It will [default to `"dev"`](https://github.com/guardian/node-riffraff-artifact/blob/f7591a7aa7bb9e6035d07b172933ceb7edd299a3/src/environment.ts#L118), matching other CI targets.

It's worth noting the default is [different from `sbt-riffraff-artifact`](https://github.com/guardian/sbt-riffraff-artifact/blob/aaa18073f035782b200913afa2f3364e647c44b1/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala#L150), but we should address that in a separate PR as we'd probably want to detect if we're running in CI and default to `"dev"` if not. This is a bigger change.

This logic is ported from https://github.com/guardian/sbt-riffraff-artifact/pull/64.