### PR TITLE
Update guidance for uploading via GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This module takes artifacts and uploads them to riff-raff for deployment.
 ### Within GitHub Actions
 `node-riffraff-artifact` will upload files to S3. When run in TeamCity, we gain credentials via TeamCity's `InstanceProfile` policy.
 
-To give GitHub Actions permissions to upload to S3 use the [`@guardian/actions-assume-aws-role` Action](https://github.com/guardian/actions-assume-aws-role).
+To give GitHub Actions permissions to upload to S3 use the [`aws-actions/configure-aws-credentials` Action](https://github.com/aws-actions/configure-aws-credentials).
 Ensure you use the Action before `node-riffraff-artifact`.
 A secret (`GU_RIFF_RAFF_ROLE_ARN`) has been added Guardian GitHub organisation that can be used for the value of `awsRoleToAssume`.
 
@@ -54,9 +54,10 @@ jobs:
         node-version: [14.17.4]
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-assume-aws-role@v1
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
-          awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.4.0
         with:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module takes artifacts and uploads them to riff-raff for deployment.
 
 To give GitHub Actions permissions to upload to S3 use the [`aws-actions/configure-aws-credentials` Action](https://github.com/aws-actions/configure-aws-credentials).
 Ensure you use the Action before `node-riffraff-artifact`.
-A secret (`GU_RIFF_RAFF_ROLE_ARN`) has been added Guardian GitHub organisation that can be used for the value of `awsRoleToAssume`.
+A secret (`GU_RIFF_RAFF_ROLE_ARN`) has been added Guardian GitHub organisation that can be used for the value of `role-to-assume`.
 
 For example:
 ```yaml


### PR DESCRIPTION
Related to: https://github.com/guardian/actions-assume-aws-role/pull/80.