### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **This project is DEPRECATED and you should use
 https://github.com/guardian/actions-riff-raff/ instead. Note, if you are still
-using Teamcity you should stick with this project for now.**
+using Teamcity you should stick with this project, but we recommend migrating to Github Actions.**
 
 This module takes artifacts and uploads them to riff-raff for deployment.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # node-riffraff-artifact
 
+**This project is DEPRECATED and you should use
+https://github.com/guardian/actions-riff-raff/ instead. Note, if you are still
+using Teamcity you should stick with this project for now.**
+
 This module takes artifacts and uploads them to riff-raff for deployment.
 
 ## How to use
 
-1. Install `@guardian/node-riffraff-artifact`: 
-    
+1. Install `@guardian/node-riffraff-artifact`:
+
     `npm i -D @guardian/node-riffraff-artifact` OR `yarn add --dev @guardian/node-riffraff-artifact`
 
 2. Create a file named `artifact.json` in the same directory as your `package.json`.


### PR DESCRIPTION
https://github.com/guardian/actions-riff-raff/ is a better option for GHA projects (which we expect to be the default for most projects going forward).